### PR TITLE
A tool and an API to manipulate Docker images across different registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Please take a quick gander at the [contribution guidelines](CONTRIBUTE.md) first
 * [goxc](https://github.com/laher/goxc) - build tool for Go, with a focus on cross-compiling and packaging.
 * [hk](https://github.com/heroku/hk) - Heroku command-line interface in Go.
 * [kala](https://github.com/ajvb/kala) - Simplistic, modern, and performant job scheduler.
+* [lstags](https://github.com/ivanilves/lstags) - manipulates Docker images across different registries. 
 * [Mora](https://github.com/emicklei/mora) - REST server for accessing MongoDB documents and meta data.
 * [ostent](https://github.com/ostrost/ostent) - collects and displays system metrics and optionally relays to Graphite and/or InfluxDB
 * [Packer](https://github.com/mitchellh/packer) - Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.


### PR DESCRIPTION
**lstags** is a tool and an API to manipulate Docker images across different registries

#### I myself find it awesome because 
* it helps me to maintain my private registry and speed up my docker pull
* besides it has awesome tests coverage, pretty nice code and README

https://github.com/ivanilves/lstags
